### PR TITLE
Add basic self-hosted Aurelia app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ build/Release
 
 # Dependency directory
 node_modules
+jspm_packages
+
+# Distribution directory
+dist
 
 # Optional npm cache directory
 .npm

--- a/build/babel-options.js
+++ b/build/babel-options.js
@@ -1,0 +1,11 @@
+module.exports = {
+  modules: 'system',
+  moduleIds: false,
+  comments: false,
+  compact: false,
+  stage: 2,
+  optional: [
+    'es7.decorators',
+    'es7.classProperties'
+  ]
+};

--- a/build/bundles.js
+++ b/build/bundles.js
@@ -1,0 +1,41 @@
+module.exports = {
+  "bundles": {
+    "dist/app-build": {
+      "includes": [
+        "[*.js]",
+        "*.html!text",
+        "*.css!text"
+      ],
+      "options": {
+        "inject": true,
+        "minify": true,
+        "depCache": true,
+        "rev": false
+      }
+    },
+    "dist/aurelia": {
+      "includes": [
+        "aurelia-framework",
+        "aurelia-bootstrapper",
+        "aurelia-fetch-client",
+        "aurelia-router",
+        "aurelia-animator-css",
+        "aurelia-templating-binding",
+        "aurelia-polyfills",
+        "aurelia-templating-resources",
+        "aurelia-templating-router",
+        "aurelia-loader-default",
+        "aurelia-history-browser",
+        "aurelia-logging-console",
+        "bootstrap",
+        "bootstrap/css/bootstrap.css!text"
+      ],
+      "options": {
+        "inject": true,
+        "minify": true,
+        "depCache": false,
+        "rev": false
+      }
+    }
+  }
+};

--- a/build/paths.js
+++ b/build/paths.js
@@ -1,0 +1,12 @@
+var appRoot = 'src/';
+var outputRoot = 'dist/';
+var exportSrvRoot = 'export/';
+
+module.exports = {
+  root: appRoot,
+  source: appRoot + '**/*.js',
+  html: appRoot + '**/*.html',
+  css: appRoot + '**/*.css',
+  style: 'styles/**/*.css',
+  output: outputRoot
+};

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -1,0 +1,52 @@
+var gulp = require('gulp');
+var runSequence = require('run-sequence');
+var changed = require('gulp-changed');
+var plumber = require('gulp-plumber');
+var to5 = require('gulp-babel');
+var sourcemaps = require('gulp-sourcemaps');
+var paths = require('../paths');
+var compilerOptions = require('../babel-options');
+var assign = Object.assign || require('object.assign');
+var notify = require('gulp-notify');
+var browserSync = require('browser-sync');
+
+// transpiles changed es6 files to SystemJS format
+// the plumber() call prevents 'pipe breaking' caused
+// by errors from other gulp plugins
+// https://www.npmjs.com/package/gulp-plumber
+gulp.task('build-system', function() {
+  return gulp.src(paths.source)
+    .pipe(plumber({errorHandler: notify.onError('Error: <%= error.message %>')}))
+    .pipe(changed(paths.output, {extension: '.js'}))
+    .pipe(sourcemaps.init({loadMaps: true}))
+    .pipe(to5(assign({}, compilerOptions, {modules: 'system'})))
+    .pipe(sourcemaps.write({includeContent: false, sourceRoot: '/src'}))
+    .pipe(gulp.dest(paths.output));
+});
+
+// copies changed html files to the output directory
+gulp.task('build-html', function() {
+  return gulp.src(paths.html)
+    .pipe(changed(paths.output, {extension: '.html'}))
+    .pipe(gulp.dest(paths.output));
+});
+
+// copies changed css files to the output directory
+gulp.task('build-css', function() {
+  return gulp.src(paths.css)
+    .pipe(changed(paths.output, {extension: '.css'}))
+    .pipe(gulp.dest(paths.output))
+    .pipe(browserSync.stream());
+});
+
+// this task calls the clean task (located
+// in ./clean.js), then runs the build-system
+// and build-html tasks in parallel
+// https://www.npmjs.com/package/gulp-run-sequence
+gulp.task('build', function(callback) {
+  return runSequence(
+    'clean',
+    ['build-system', 'build-html', 'build-css'],
+    callback
+  );
+});

--- a/build/tasks/bundle.js
+++ b/build/tasks/bundle.js
@@ -1,0 +1,18 @@
+var gulp = require('gulp');
+var bundler = require('aurelia-bundler');
+var bundles = require('../bundles.js');
+
+var config = {
+  force: true,
+  baseURL: '.',
+  configPath: './config.js',
+  bundles: bundles.bundles
+};
+
+gulp.task('bundle', ['build'], function() {
+  return bundler.bundle(config);
+});
+
+gulp.task('unbundle', function() {
+  return bundler.unbundle(config);
+});

--- a/build/tasks/clean.js
+++ b/build/tasks/clean.js
@@ -1,0 +1,10 @@
+var gulp = require('gulp');
+var paths = require('../paths');
+var del = require('del');
+var vinylPaths = require('vinyl-paths');
+
+// deletes all files in the output path
+gulp.task('clean', ['unbundle'], function() {
+  return gulp.src([paths.output])
+    .pipe(vinylPaths(del));
+});

--- a/build/tasks/serve.js
+++ b/build/tasks/serve.js
@@ -1,0 +1,38 @@
+var gulp = require('gulp');
+var browserSync = require('browser-sync');
+
+// this task utilizes the browsersync plugin
+// to create a dev server instance
+// at http://localhost:9000
+gulp.task('serve', ['build'], function(done) {
+  browserSync({
+    online: false,
+    open: false,
+    port: 9000,
+    server: {
+      baseDir: ['.'],
+      middleware: function(req, res, next) {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        next();
+      }
+    }
+  }, done);
+});
+
+// this task utilizes the browsersync plugin
+// to create a dev server instance
+// at http://localhost:9000
+gulp.task('serve-bundle', ['bundle'], function(done) {
+  browserSync({
+    online: false,
+    open: false,
+    port: 9000,
+    server: {
+      baseDir: ['.'],
+      middleware: function(req, res, next) {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        next();
+      }
+    }
+  }, done);
+});

--- a/build/tasks/watch.js
+++ b/build/tasks/watch.js
@@ -1,0 +1,22 @@
+var gulp = require('gulp');
+var paths = require('../paths');
+var browserSync = require('browser-sync');
+
+// outputs changes to files to the console
+function reportChange(event) {
+  console.log('File ' + event.path + ' was ' + event.type + ', running tasks...');
+}
+
+// this task wil watch for changes
+// to js, html, and css files and call the
+// reportChange method. Also, by depending on the
+// serve task, it will instantiate a browserSync session
+gulp.task('watch', ['serve'], function() {
+  gulp.watch(paths.source, ['build-system', browserSync.reload]).on('change', reportChange);
+  gulp.watch(paths.html, ['build-html', browserSync.reload]).on('change', reportChange);
+  gulp.watch(paths.css, ['build-css']).on('change', reportChange);
+  gulp.watch(paths.style, function() {
+    return gulp.src(paths.style)
+      .pipe(browserSync.stream());
+  }).on('change', reportChange);
+});

--- a/config.js
+++ b/config.js
@@ -1,0 +1,176 @@
+System.config({
+  baseURL: "/",
+  defaultJSExtensions: true,
+  transpiler: "babel",
+  babelOptions: {
+    "optional": [
+      "runtime",
+      "optimisation.modules.system"
+    ]
+  },
+  paths: {
+    "*": "dist/*",
+    "github:*": "jspm_packages/github/*",
+    "npm:*": "jspm_packages/npm/*"
+  },
+  map: {
+    "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.0-beta.1.1.4",
+    "aurelia-fetch-client": "npm:aurelia-fetch-client@1.0.0-beta.1.1.1",
+    "aurelia-framework": "npm:aurelia-framework@1.0.0-beta.1.1.4",
+    "aurelia-router": "npm:aurelia-router@1.0.0-beta.1.1.3",
+    "babel": "npm:babel-core@5.8.35",
+    "babel-runtime": "npm:babel-runtime@5.8.35",
+    "core-js": "npm:core-js@1.2.6",
+    "github:jspm/nodelibs-assert@0.1.0": {
+      "assert": "npm:assert@1.3.0"
+    },
+    "github:jspm/nodelibs-path@0.1.0": {
+      "path-browserify": "npm:path-browserify@0.0.0"
+    },
+    "github:jspm/nodelibs-process@0.1.2": {
+      "process": "npm:process@0.11.2"
+    },
+    "github:jspm/nodelibs-util@0.1.0": {
+      "util": "npm:util@0.10.3"
+    },
+    "npm:assert@1.3.0": {
+      "util": "npm:util@0.10.3"
+    },
+    "npm:aurelia-binding@1.0.0-beta.1.2.2": {
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-bootstrapper@1.0.0-beta.1.1.4": {
+      "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0-beta.1.1.1",
+      "aurelia-framework": "npm:aurelia-framework@1.0.0-beta.1.1.4",
+      "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.1.1",
+      "aurelia-history-browser": "npm:aurelia-history-browser@1.0.0-beta.1.1.4",
+      "aurelia-loader-default": "npm:aurelia-loader-default@1.0.0-beta.1.1.3",
+      "aurelia-logging-console": "npm:aurelia-logging-console@1.0.0-beta.1.1.4",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.1.4",
+      "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.0.6",
+      "aurelia-router": "npm:aurelia-router@1.0.0-beta.1.1.3",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.4",
+      "aurelia-templating-binding": "npm:aurelia-templating-binding@1.0.0-beta.1.1.2",
+      "aurelia-templating-resources": "npm:aurelia-templating-resources@1.0.0-beta.1.1.3",
+      "aurelia-templating-router": "npm:aurelia-templating-router@1.0.0-beta.1.1.2"
+    },
+    "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-event-aggregator@1.0.0-beta.1.1.1": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2"
+    },
+    "npm:aurelia-framework@1.0.0-beta.1.1.4": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.2.2",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5",
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.1.1",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.1",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.1",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.4"
+    },
+    "npm:aurelia-history-browser@1.0.0-beta.1.1.4": {
+      "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.1.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-loader-default@1.0.0-beta.1.1.3": {
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.1.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-loader@1.0.0-beta.1.1.1": {
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-logging-console@1.0.0-beta.1.1.4": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-metadata@1.0.0-beta.1.1.6": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-pal-browser@1.0.0-beta.1.1.4": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-polyfills@1.0.0-beta.1.0.6": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-route-recognizer@1.0.0-beta.1.1.3": {
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-router@1.0.0-beta.1.1.3": {
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5",
+      "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0-beta.1.1.1",
+      "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.1.1",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.1",
+      "aurelia-route-recognizer": "npm:aurelia-route-recognizer@1.0.0-beta.1.1.3"
+    },
+    "npm:aurelia-task-queue@1.0.0-beta.1.1.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
+    },
+    "npm:aurelia-templating-binding@1.0.0-beta.1.1.2": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.2.2",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.4"
+    },
+    "npm:aurelia-templating-resources@1.0.0-beta.1.1.3": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.2.2",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5",
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.1.1",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.1",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.1",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.4"
+    },
+    "npm:aurelia-templating-router@1.0.0-beta.1.1.2": {
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.1",
+      "aurelia-router": "npm:aurelia-router@1.0.0-beta.1.1.3",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.4"
+    },
+    "npm:aurelia-templating@1.0.0-beta.1.1.4": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.2.2",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5",
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.1.1",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.1",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.1"
+    },
+    "npm:babel-runtime@5.8.35": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:core-js@1.2.6": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:inherits@2.0.1": {
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:path-browserify@0.0.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:process@0.11.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0"
+    },
+    "npm:util@0.10.3": {
+      "inherits": "npm:inherits@2.0.1",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    }
+  }
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,3 @@
+// all gulp tasks are located in the ./build/tasks directory
+// gulp configuration is in files in ./build directory
+require('require-dir')('build/tasks');

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<html>
+    <body aurelia-app="main">
+        Loading...
+        <script src="jspm_packages/system.js"></script>
+        <script src="config.js"></script>
+        <script>
+        System.import('aurelia-bootstrapper');
+        </script>
+    </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "thatsfine",
+  "version": "1.0.0",
+  "description": "An Aurelia client for Structure.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aptera/thatsfine.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/aptera/thatsfine/issues"
+  },
+  "homepage": "https://github.com/aptera/thatsfine#readme",
+  "devDependencies": {
+    "aurelia-bundler": "^0.3.2",
+    "babel": "^5.8.23",
+    "browser-sync": "^2.11.1",
+    "del": "^2.2.0",
+    "gulp": "^3.9.1",
+    "gulp-babel": "^5.1.0",
+    "gulp-changed": "^1.3.0",
+    "gulp-notify": "^2.2.0",
+    "gulp-plumber": "^1.1.0",
+    "gulp-sourcemaps": "^1.6.0",
+    "jspm": "^0.16.31",
+    "object.assign": "^4.0.3",
+    "require-dir": "^0.3.0",
+    "run-sequence": "^1.1.5",
+    "vinyl-paths": "^2.1.0"
+  },
+  "jspm": {
+    "dependencies": {
+      "aurelia-bootstrapper": "npm:aurelia-bootstrapper@^1.0.0-beta.1.1.4",
+      "aurelia-fetch-client": "npm:aurelia-fetch-client@^1.0.0-beta.1.1.1",
+      "aurelia-framework": "npm:aurelia-framework@^1.0.0-beta.1.1.4",
+      "aurelia-router": "npm:aurelia-router@^1.0.0-beta.1.1.3"
+    },
+    "devDependencies": {
+      "babel": "npm:babel-core@^5.8.24",
+      "babel-runtime": "npm:babel-runtime@^5.8.24",
+      "core-js": "npm:core-js@^1.1.4"
+    }
+  }
+}

--- a/src/app.html
+++ b/src/app.html
@@ -1,0 +1,7 @@
+<template>
+  <nav-bar router.bind="router"></nav-bar>
+
+  <div class="page-host">
+    <router-view></router-view>
+  </div>
+</template>

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,10 @@
+export class App {
+  configureRouter(config, router) {
+    config.title = 'Aurelia';
+    config.map([
+      { route: ['', 'welcome'], name: 'welcome',      moduleId: 'welcome',      nav: true, title: 'Welcome' }
+    ]);
+
+    this.router = router;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,7 @@
+export function configure(aurelia) {
+  aurelia.use
+    .standardConfiguration()
+    .developmentLogging();
+
+  aurelia.start().then(() => aurelia.setRoot());
+}

--- a/src/welcome.html
+++ b/src/welcome.html
@@ -1,0 +1,3 @@
+<template>
+    Welcome to Aurelia!
+</template>

--- a/src/welcome.js
+++ b/src/welcome.js
@@ -1,0 +1,4 @@
+//import {computedFrom} from 'aurelia-framework';
+
+export class Welcome {
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}


### PR DESCRIPTION
Creating the shell around the Aurelia app, using a modified verison of the es2016 Aurelia Skeleton application, and having the app be served through browserSync since we aren't sure if everyone will have VS 2015 which we'd want if we were hosting through ASP.NET Core, and we decided we didn't want to host through 4.5.  Obviously that can all change, but it shouldn't have an impact on the development of the actual Aurelia app.
